### PR TITLE
Fixed a bug in blink.cmp causing editor freezes on WSL2 systems

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -857,6 +857,13 @@ require('lazy').setup({
         default = { 'lsp', 'path', 'snippets', 'lazydev' },
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
+          -- On WSL2, blink.cmp may cause the editor to freeze due to a known limitation.
+          -- To address this issue, uncomment the following configuration:
+          -- cmdline = {
+          --   enabled = function()
+          --     return vim.fn.getcmdtype() ~= ':' or not vim.fn.getcmdline():match "^[%%0-9,'<>%-]*!"
+          --   end,
+          -- },
         },
       },
 


### PR DESCRIPTION
Merge https://github.com/nvim-lua/kickstart.nvim/pull/1634